### PR TITLE
SplaschScreen

### DIFF
--- a/M_M_App _exam/M_M_App/ContentView.swift
+++ b/M_M_App _exam/M_M_App/ContentView.swift
@@ -10,7 +10,8 @@ import FirebaseFirestore
 
 struct ContentView: View {
     
-   @StateObject var db = DbConnection()
+    @StateObject var db = DbConnection()
+    @State var showSplashScreen = true
     // Börja från SplashScreen
     
     var body: some View {
@@ -18,30 +19,42 @@ struct ContentView: View {
         
         if let user = db.currentUser {
             NavigationStack{
+                
                 VStack{
-                    MainView().environmentObject(DbConnection())
+                    /// Börja fr SplashScreen
+                    if let user = db.currentUser{
+                        if showSplashScreen{
+                            SplashScreenView()
+                            /// onAppear in need to show SplashScreen again for 0.5 sek
+                                .onAppear{
+                                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.5 ){
+                                        showSplashScreen = false
+                                    }
+                                }
+                        }else{
+                            MainView().environmentObject(db)
+                        }
+                    }else{
+                        NavigationStack{
+                            LoginView(db: db)
+                        }
+                    }
+                    
                 }
             }
             
             
-        } else{
+        }
+        else{
             NavigationStack{
                 LoginView(db: db)
-               // SplashScreenView()
+                // SplashScreenView()
             }
-           
+            
+            
+            
         }
-            
-       
-            
-             
-            
-            
-        
-        
-        
     }
-    
     
 }
     struct ContentView_Previews: PreviewProvider {

--- a/M_M_App _exam/M_M_App/Views/UnAuthenticated/SplashScreenView.swift
+++ b/M_M_App _exam/M_M_App/Views/UnAuthenticated/SplashScreenView.swift
@@ -14,12 +14,23 @@ struct SplashScreenView: View {
     @State var opacity: Double = 0.6
     @State var isActive = false
     
+    @State var currentUser: UserData? //= UserData(firstname: "", lastname: "")
+    
     
     var body: some View {
         
         if isActive {
-            /// Navigate to LoginView
-            LoginView(db: DbConnection())
+           
+            /// if currentUser != nil
+            if currentUser?.id != nil {
+                /// Navigate to MainView
+                MainView()
+            }else{
+                /// Else to LoginView
+                LoginView(db: DbConnection())
+            }
+           
+           
         }else {
             
             VStack{


### PR DESCRIPTION
använder .id för currentUser istället för bara currentUser. Villkor ändrat för när SplaschScreen ska visas.
Fix Splash ska visas när användaren lämnar appen och komma tillbaka utan att logga ut. Koderna ändrade i SplashScreenView och i ContentView